### PR TITLE
Fixes error with missing library

### DIFF
--- a/framework/pom.xml
+++ b/framework/pom.xml
@@ -34,6 +34,10 @@
             <id>smartbear-sweden-plugin-repository</id>
             <url>http://www.soapui.org/repository/maven2/</url>
         </repository>
+        <repository>
+            <id>libs</id>
+            <url>https://repo.nds.rub.de/repository/libs/</url>
+        </repository>
         <!-- This is no longer needed, using 
             https://repo.nds.rub.de:8443/archiva/repository/libs/
             instead


### PR DESCRIPTION
lablib-checkboxtree-3.3.jar is missing from the SoapUI repository but present on the repo.nds.rub.de repository.